### PR TITLE
Fix table background

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -655,7 +655,7 @@ $text-muted:                     $gray-500;
 // $table-cell-vertical-align:   top !default;
 
 $table-bg:                    $white;
-$table-accent-bg:             $gray-200;
+// $table-accent-bg:             transparent !default;
 $table-hover-bg:              $brand-apricot-25;
 
 // $table-th-font-weight:        null !default;


### PR DESCRIPTION
Die aktuelle Version unsers BS-Themes rendert die Tabellen mit einem grauen Hintergrund:
Ohne Zebra
<img width="1193" alt="Bildschirmfoto 2022-05-11 um 17 37 27" src="https://user-images.githubusercontent.com/1646402/167890315-2e18ab3f-f2e1-43d2-bff7-10eff51948e5.png">

Mit Zebra
<img width="1208" alt="Bildschirmfoto 2022-05-11 um 17 35 57" src="https://user-images.githubusercontent.com/1646402/167890760-2c932270-4979-44df-b6c8-a0d09516b925.png">

Die Tabelle soll aber so aussehen:
Ohne Zebra
<img width="1175" alt="Bildschirmfoto 2022-05-11 um 17 37 07" src="https://user-images.githubusercontent.com/1646402/167890349-a1980e3d-6f0f-42ad-886b-dec109567b41.png">
bzw. mit Zebra
<img width="1167" alt="Bildschirmfoto 2022-05-11 um 17 36 19" src="https://user-images.githubusercontent.com/1646402/167890810-d3cdf84c-37f1-4377-8309-5f2ea468c538.png">


Mein PR fixt dieses Problem :)


